### PR TITLE
Remove require pry from non dev code

### DIFF
--- a/lib/cztop/monitor.rb
+++ b/lib/cztop/monitor.rb
@@ -1,5 +1,3 @@
-require "pry"
-
 module CZTop
   # CZMQ monitor. Listen for socket events.
   #


### PR DESCRIPTION
`pry` isn't in the gemspec dependencies so requiring it without your own `pry` in the Gemfile causes things to blow up. This PR fixes that.
