### PR TITLE
Add enabling of IPv6

### DIFF
--- a/lib/cztop/zsock_options.rb
+++ b/lib/cztop/zsock_options.rb
@@ -273,15 +273,15 @@ module CZTop
         Zsock.set_linger(@zocket, new_value)
       end
 
-      # @return [Integer] current value of ipv6
-      def ipv6() Zsock.ipv6(@zocket) end
-      # Set the IPv6 option for the socket. A value of 1 means IPv6 is
-      # enabled on the socket, while 0 means the socket will use only IPv4.
-      # When IPv6 is enabled the socket will connect to, or accept 
+      # @return [Boolean] current value of ipv6
+      def ipv6() Zsock.ipv6(@zocket) != 0 end
+      # Set the IPv6 option for the socket. A value of true means IPv6 is
+      # enabled on the socket, while false means the socket will use only
+      # IPv4.  When IPv6 is enabled the socket will connect to, or accept 
       # connections from, both IPv4 and IPv6 hosts.
-      # @param new_value [Integer] new value for ipv6
+      # @param new_value [Boolean] new value for ipv6
       def ipv6=(new_value)
-        Zsock.set_ipv6(@zocket, new_value)
+        Zsock.set_ipv6(@zocket, (new_value == true) ? 1 : 0)
       end
 # TODO: a reasonable subset of these
 #//  Get socket options

--- a/lib/cztop/zsock_options.rb
+++ b/lib/cztop/zsock_options.rb
@@ -274,14 +274,15 @@ module CZTop
       end
 
       # @return [Boolean] current value of ipv6
-      def ipv6() Zsock.ipv6(@zocket) != 0 end
+      def ipv6?() Zsock.ipv6(@zocket) != 0 end
       # Set the IPv6 option for the socket. A value of true means IPv6 is
       # enabled on the socket, while false means the socket will use only
       # IPv4.  When IPv6 is enabled the socket will connect to, or accept 
       # connections from, both IPv4 and IPv6 hosts.
+      # Default is false.
       # @param new_value [Boolean] new value for ipv6
       def ipv6=(new_value)
-        Zsock.set_ipv6(@zocket, (new_value == true) ? 1 : 0)
+        Zsock.set_ipv6(@zocket, new_value ? 1 : 0)
       end
 # TODO: a reasonable subset of these
 #//  Get socket options

--- a/lib/cztop/zsock_options.rb
+++ b/lib/cztop/zsock_options.rb
@@ -273,13 +273,22 @@ module CZTop
         Zsock.set_linger(@zocket, new_value)
       end
 
+      # @return [Integer] current value of ipv6
+      def ipv6() Zsock.ipv6(@zocket) end
+      # Set the IPv6 option for the socket. A value of 1 means IPv6 is
+      # enabled on the socket, while 0 means the socket will use only IPv4.
+      # When IPv6 is enabled the socket will connect to, or accept 
+      # connections from, both IPv4 and IPv6 hosts.
+      # @param new_value [Integer] new value for ipv6
+      def ipv6=(new_value)
+        Zsock.set_ipv6(@zocket, new_value)
+      end
 # TODO: a reasonable subset of these
 #//  Get socket options
 #int zsock_gssapi_server (void *self);
 #int zsock_gssapi_plaintext (void *self);
 #char * zsock_gssapi_principal (void *self);
 #char * zsock_gssapi_service_principal (void *self);
-#int zsock_ipv6 (void *self);
 #int zsock_immediate (void *self);
 #int zsock_type (void *self);
 #int zsock_affinity (void *self);
@@ -311,7 +320,6 @@ module CZTop
 #void zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext);
 #void zsock_set_gssapi_principal (void *self, const char * gssapi_principal);
 #void zsock_set_gssapi_service_principal (void *self, const char * gssapi_service_principal);
-#void zsock_set_ipv6 (void *self, int ipv6);
 #void zsock_set_immediate (void *self, int immediate);
 #void zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 #void zsock_set_affinity (void *self, int affinity);

--- a/spec/cztop/zsock_options_spec.rb
+++ b/spec/cztop/zsock_options_spec.rb
@@ -448,6 +448,38 @@ describe CZTop::ZsockOptions do
       end
     end
 
+    describe "#ipv6=" do
+      it "can enable IPv6" do
+        expect(CZMQ::FFI::Zsock).to receive(:set_ipv6)
+          .with(socket, 1)
+        options.ipv6 = true
+      end
+      it "can disable IPv6" do
+        expect(CZMQ::FFI::Zsock).to receive(:set_ipv6)
+          .with(socket, 0)
+        options.ipv6 = false
+      end
+    end
+    describe "#ipv6?" do
+      context "with default setting" do
+        it "returns false" do
+          refute_operator options, :ipv6?
+        end
+      end
+      context "with ipv6 enabled" do
+        before(:each) {options.ipv6 = true}
+        it "returns true" do
+          assert_operator options, :ipv6?
+        end
+      end
+      context "with ipv6 disabled" do
+        before(:each) {options.ipv6 = false}
+        it "returns false" do
+          refute_operator options, :ipv6?
+        end
+      end
+    end
+	
     describe "#[]" do
       context "with vague option name" do
         let(:identity) { "foobar" }


### PR DESCRIPTION
I copied the description from the ZMQ description of ipv6 support in zmq_setsockopt.  Originally I thought to just copy the behavior for using integers 0/1, but it seemed reasonable to use false/true, given the boolean nature of the setting.  Thoughts?
